### PR TITLE
Basic GNU/Linux compilation instructions (with a focus on Debian 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,24 +38,54 @@ This system is more complex than what I have explained so far, but in a basic se
 
 Hopefully, this explains how and why the limit is there.
 
-### Compiling on GNU/Linux
+## Compiling on GNU/Linux
 
-## Debian 10 & Derivatives
+### Debian 10 & Derivatives
+
+There are two options when compiling on a Debian GNU/Linux system. The first is to use the version of rustc from the official repositories, which runs the risk of being out of date.
+
+#### Method 1: Using Debian's rust packages
+
+**Note: This method may not work in the future as Debian's packaged versions of rustc, cargo, etc are often out of date. While at the time of writing this worked, please try Method 2 before filing an issue**
 
 To successfully build on a Debian 10-based GNU/Linux system, first install rustc and cargo.
 At the time of writing, the versions included with Debian 10 work, which are cargo and rustc version 1.43.0.
 
+1. Install rustc and cargo using apt
+
 `sudo apt install rustc cargo`
 
-Then clone the git repository into your desired location.
+2. Clone the git repository into your desired location.
 
 `git clone https://github.com/McSib/e621_downloader`
 
-After it's finished cloning, simply enter the directory and run the following:
+3. After cloning is complete, simply enter the directory and run the following:
 
-`cargo build`
+`cargo build --release`
 
 This could take quite a while depending on your CPU. This has only been tested on an amd64 CPU (an Intel Core 2 Duo), which took about fourty minutes.
+
+4. The binary is should be located at: `./target/release/e621_downloader`.  If needed, make the binary executable by running `chmod a+x ./e621_downloader` after navigating to ./target/release/
+
+#### Method 2: Using rustup
+
+This method involves using rustup, the tool provided by Rust for installation and updating of rust and cargo for GNU/Linux systems.
+
+**If you already have an up to date rustup installion, skip this step**
+
+1. Go to [Rust's 'Getting Started'](https://www.rust-lang.org/learn/get-started) guide for up-to-date directions on installing rustup.
+
+After the rustup installation is complete, you must run `source $HOME/.cargo/envo` if you choose not to logout/login. This only needs to be done once, as after installation rust will automatically be added to your path.
+
+2. Clone the git repository into your desired location.
+
+`git clone https://github.com/McSib/e621_downloader`
+
+3. After cloning is complete, simply enter the directory and run the following:
+
+`cargo build --release`
+
+4. The binary is should be located at: ./target/release/e621_downloader.  If needed, make the binary executable by running `chmod a+x ./e621_downloader` after navigating to ./target/release/
 
 ### macOS Builds
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,25 @@ This system is more complex than what I have explained so far, but in a basic se
 
 Hopefully, this explains how and why the limit is there.
 
-### I want this compiled for Mac/Linux!
+### Compiling on GNU/Linux
 
-I don't have access to these systems right now and can't properly test and compile my program to see if it will even run. However, if you want to try and see if my program will work on those systems, please try! I would love to port to those systems, but I'm too limited to be able to fully try it. If it works completely, let me know, I would love to supply Mac and Linux with this software too.
+## Debian 10 & Derivatives
 
+To successfully build on a Debian 10-based GNU/Linux system, first install rustc and cargo.
+At the time of writing, the versions included with Debian 10 work, which are cargo and rustc version 1.43.0.
+
+`sudo apt install rustc cargo`
+
+Then clone the git repository into your desired location.
+
+`git clone https://github.com/McSib/e621_downloader`
+
+After it's finished cloning, simply enter the directory and run the following:
+
+`cargo build`
+
+This could take quite a while depending on your CPU. This has only been tested on an amd64 CPU (an Intel Core 2 Duo), which took about fourty minutes.
+
+### macOS Builds
+
+Building on macOS remain untested. If you have access to this platform, please make a PR or file an issue for build instructions, potential errors, and fixes.


### PR DESCRIPTION
I've added some basic GNU/Linux compilation instructions. This was done on PureOS Amber, which is a version of Debian 10 which removes some non-free components to meet the Free Software Foundation's guidelines for what's considered a free distribution. The packages relevant to compiling e621 downloader were not modified from Debian 10's packages.

This should hold true for other GNU/Linux systems (minus instructions for installing rustc and cargo).

Feel free to ask any questions or make needed edits to better fit your preferred documentation style.

In case it does not go without saying, these contributions are licensed under the Apache License 2.0.