### PR TITLE
Replace `failure` calls with `anyhow` equivalents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler32"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,24 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
-dependencies = [
- "addr2line",
- "cfg-if 0.1.10",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base64"
@@ -148,10 +125,10 @@ dependencies = [
 name = "e621_downloader"
 version = "1.7.2"
 dependencies = [
+ "anyhow",
  "base64-url",
  "console",
  "dialoguer",
- "failure",
  "indicatif",
  "log",
  "once_cell",
@@ -178,28 +155,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
 ]
 
 [[package]]
@@ -290,12 +245,6 @@ dependencies = [
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "h2"
@@ -513,15 +462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,12 +515,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "object"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
@@ -818,12 +752,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
 name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,18 +912,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1189,12 +1105,6 @@ name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ simplelog = "0.12.0"
 reqwest = { version = "0.11.13", features = ["blocking", "rustls-tls", "json"] }
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
-failure = "0.1.8"
+anyhow = "1.0"

--- a/src/e621/blacklist.rs
+++ b/src/e621/blacklist.rs
@@ -17,7 +17,7 @@
 
 use std::cmp::Ordering;
 
-use failure::ResultExt;
+use anyhow::Context;
 
 use crate::e621::io::parser::BaseParser;
 use crate::e621::sender::entries::{PostEntry, UserEntry};
@@ -462,9 +462,8 @@ impl FlagWorker {
                     let user_id = tag
                         .name
                         .parse::<i64>()
-                        .with_context(|e| {
-                            error!("Failed to parse blacklisted user id: {}!", tag.name);
-                            format!("{e}")
+                        .with_context(|| {
+                            format!("Failed to parse blacklisted user id: {}!", tag.name)
                         })
                         .unwrap();
                     self.flag_user(user_id, post.uploader_id, tag.negated);

--- a/src/e621/io/mod.rs
+++ b/src/e621/io/mod.rs
@@ -19,7 +19,7 @@ use std::io;
 use std::path::Path;
 use std::process::exit;
 
-use failure::Error;
+use anyhow::Error;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_str, to_string_pretty};

--- a/src/e621/io/tag.rs
+++ b/src/e621/io/tag.rs
@@ -16,7 +16,7 @@
 
 use std::fs::read_to_string;
 
-use failure::{Error, ResultExt};
+use anyhow::{Context, Error};
 
 use crate::e621::io::emergency_exit;
 use crate::e621::io::parser::BaseParser;
@@ -136,10 +136,9 @@ pub(crate) fn parse_tag_file(request_sender: &RequestSender) -> Result<Vec<Group
     TagParser {
         parser: BaseParser::new(
             read_to_string(TAG_NAME)
-                .with_context(|e| {
+                .with_context(|| {
                     error!("Unable to read tag file!");
-                    trace!("Possible I/O block when trying to read tag file...");
-                    format!("{e}")
+                    format!("Possible I/O block when trying to read tag file...")
                 })
                 .unwrap(),
         ),

--- a/src/e621/mod.rs
+++ b/src/e621/mod.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use dialoguer::Confirm;
-use failure::ResultExt;
+use anyhow::Context;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 
 use crate::e621::blacklist::Blacklist;
@@ -73,10 +73,9 @@ impl E621WebConnector {
             .show_default(true)
             .default(false)
             .interact()
-            .with_context(|e| {
+            .with_context(|| {
                 error!("Failed to setup confirmation prompt!");
-                trace!("Terminal unable to set up confirmation prompt...");
-                format!("{e}")
+                format!("Terminal unable to set up confirmation prompt...")
             })
             .unwrap();
 
@@ -120,10 +119,9 @@ impl E621WebConnector {
     /// Saves image to download directory.
     fn save_image(&self, file_path: &str, bytes: &[u8]) {
         write(file_path, bytes)
-            .with_context(|e| {
+            .with_context(|| {
                 error!("Failed to save image!");
-                trace!("A downloaded image was unable to be saved...");
-                format!("{e}")
+                format!("A downloaded image was unable to be saved...")
             })
             .unwrap();
         trace!("Saved {file_path}...");
@@ -228,11 +226,9 @@ impl E621WebConnector {
 
                 let parent_path = file_path.parent().unwrap();
                 create_dir_all(parent_path)
-                    .with_context(|e| {
+                    .with_context(|| {
                         error!("Could not create directories for images!");
-                        trace!("Directory path unable to be created...");
-                        trace!("Path: \"{}\"", parent_path.to_str().unwrap());
-                        format!("{e}")
+                        format!("Directory path unable to be created...\nPath: \"{}\"", parent_path.to_str().unwrap())
                     })
                     .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@
  */
 
 #[macro_use]
-extern crate failure;
+extern crate anyhow;
 #[macro_use]
 extern crate log;
 
@@ -23,7 +23,7 @@ extern crate log;
 use std::env::consts::{ARCH, DLL_EXTENSION, DLL_PREFIX, DLL_SUFFIX, EXE_EXTENSION, EXE_SUFFIX, FAMILY, OS};
 use std::fs::File;
 
-use failure::Error;
+use anyhow::Error;
 use log::LevelFilter;
 use simplelog::{ColorChoice, CombinedLogger, Config, ConfigBuilder, TerminalMode, TermLogger, WriteLogger};
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -19,7 +19,7 @@ use std::fs::write;
 use std::path::Path;
 
 use console::Term;
-use failure::Error;
+use anyhow::Error;
 
 use crate::e621::E621WebConnector;
 use crate::e621::io::{Config, emergency_exit, Login};


### PR DESCRIPTION
Hello! Felt like tinkering, and remembered this program and felt like I'd help out.

Since `failure` has been deprecated, I was able to refactor everything to `anyhow` pretty easily. Uses of `failure::Error` are one-to-one, but `with_context` calls needed to be tweaked a bit, feel free to change any of that if I made a mistake.

Fixes #95.

(Also, in the process of making this, I hit the same huge memory usage issue I've seen some other issues about. Think I might try and figure out what's causing that in a separate PR.)

~s